### PR TITLE
feat: add slither check

### DIFF
--- a/.github/workflows/governance-checks.yaml
+++ b/.github/workflows/governance-checks.yaml
@@ -50,6 +50,9 @@ jobs:
         with:
           python-version: '3.10'
 
+      - name: Install solc-select
+        run: pip3 install solc-select
+
       - name: Install Slither
         run: pip3 install slither-analyzer
 

--- a/.github/workflows/governance-checks.yaml
+++ b/.github/workflows/governance-checks.yaml
@@ -45,6 +45,14 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+
+      - name: Install Slither
+        run: pip3 install slither-analyzer
+
       - name: Run checks
         run: yarn start
         env:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Some notes on the outputs of reports:
 
 - If a transaction reverts, that will be reported in the state changes section
 - State changes and events around the proposal execution process, such as the `ExecuteTransaction` event and `queuedTransactions` state changes, are omitted from reports to reduce noise
+- Slither analysis for the timelock, governor proxy, and governor implementation is skipped to reduce noise in the output. Note that skipping analysis for the implementation on historical proposals requires an archive node, and a warning will be shown if archive data is required not available
 
 ## Usage
 

--- a/checks/check-logs.ts
+++ b/checks/check-logs.ts
@@ -1,4 +1,5 @@
 import { getAddress } from '@ethersproject/address'
+import { getContractName } from '../utils/clients/tenderly'
 import { ProposalCheck, Log } from '../types'
 
 /**
@@ -37,14 +38,7 @@ export const checkLogs: ProposalCheck = {
     for (const [address, logs] of Object.entries(events)) {
       // Use contracts array to get contract name of address
       const contract = sim.contracts.find((c) => c.address === address)
-      let contractName = contract?.contract_name
-
-      // If the contract is a token, include the full token name. This is useful in cases where the
-      // token is a proxy, so the contract name doesn't give much useful information
-      if (contract?.token_data?.name) contractName += ` (${contract?.token_data?.name})`
-
-      // Lastly, append the contract address and save it off
-      info += `\n    - ${contractName} at \`${address}\``
+      info += `\n    - ${getContractName(contract)}`
 
       // Format log data for report
       logs.forEach((log) => {

--- a/checks/check-slither.ts
+++ b/checks/check-slither.ts
@@ -1,0 +1,76 @@
+import { writeFileSync, unlinkSync } from 'fs'
+import util from 'util'
+import { exec as execCallback } from 'child_process'
+import { ProposalCheck } from '../types'
+
+// convert exec method from a callback to a promise
+const exec = util.promisify(execCallback)
+
+// Data returned from command execution
+type ExecOutput = {
+  stdout: string
+  stderr: string
+}
+
+/**
+ * Runs slither against the verified contracts and reports the outputs.
+ * Assumes slither is already installed and can be run with python
+ */
+export const checkSlither: ProposalCheck = {
+  name: 'Runs slither against the verified contracts',
+  async checkProposal(proposal, sim, deps) {
+    let info = ''
+    let warnings: string[] = []
+    // For each verified contract with code, we write the files, run slither, then delete the
+    // files. We do this instead of running Slither on all contracts at once since contracts at
+    // different addresses can have the same names, which would result in an error when compiling
+    for (const contract of sim.contracts) {
+      // Get solc version used
+      const solcVersionMatch = contract.compiler_version.match(/\d*\.\d*\.\d*/)
+      if (!solcVersionMatch) {
+        const msg = `Slither not run for \`${contract.contract_name}\` at \`${contract.address}\`: could not parse solc version`
+        warnings.push(msg)
+        continue
+      }
+      const solcVersion = solcVersionMatch[0]
+
+      // Save the contract locally
+      for (const file of contract.data.contract_info) writeFileSync(file.name, file.source)
+
+      // Run slither against it
+      const output = await runSlither(solcVersion)
+      if (!output) {
+        warnings.push(`Slither execution failed for \`${contract.contract_name}\` at \`${contract.address}\``)
+        continue
+      }
+
+      // Append results to report info
+      // Note that slither supports a `--json` flag  we could use, but directly printing the formatted
+      // results in a code block is sufficient and simpler
+      info += `\n\`\`\`\n${output.stderr}\`\`\``
+
+      // Delete the contract files
+      for (const file of contract.data.contract_info) unlinkSync(file.name)
+    }
+
+    return { info: [`Slither report:${info}`], warnings, errors: [] }
+  },
+}
+
+/**
+ * Tries to run slither via python installation
+ * @dev Requires solc-select and slither to be installed
+ * @dev If you have nix/dapptools installed, you'll need to make sure the path to your python
+ * executables (find this with `which solc-select`) comes before the path to your nix executables.
+ * This may require editing your $PATH variable prior to running this check. If you don't do this,
+ * the nix version of solc will take precedence over the solc-select version, and slither will fail
+ */
+async function runSlither(solcVersion: string): Promise<ExecOutput | null> {
+  try {
+    return await exec(`solc-select install ${solcVersion} && SOLC_VERSION=${solcVersion} slither .`)
+  } catch (e: any) {
+    if ('stdout' in e) return e // output is in stdout, but slither reports results as an exception
+    console.warn(`Error: Could not run slither via Python: ${JSON.stringify(e)}`)
+    return null
+  }
+}

--- a/checks/check-slither.ts
+++ b/checks/check-slither.ts
@@ -1,6 +1,7 @@
 import { writeFileSync, unlinkSync } from 'fs'
 import util from 'util'
 import { exec as execCallback } from 'child_process'
+import { getContractName } from '../utils/clients/tenderly'
 import { ProposalCheck } from '../types'
 
 // convert exec method from a callback to a promise
@@ -46,14 +47,15 @@ export const checkSlither: ProposalCheck = {
 
       // Append results to report info
       // Note that slither supports a `--json` flag  we could use, but directly printing the formatted
-      // results in a code block is sufficient and simpler
+      // results in a code block is simpler and sufficient for now
+      info += `\n - Slither report for ${getContractName(contract)}`
       info += `\n\`\`\`\n${output.stderr}\`\`\``
 
       // Delete the contract files
       for (const file of contract.data.contract_info) unlinkSync(file.name)
     }
 
-    return { info: [`Slither report:${info}`], warnings, errors: [] }
+    return { info: [info], warnings, errors: [] }
   },
 }
 

--- a/checks/check-state-changes.ts
+++ b/checks/check-state-changes.ts
@@ -1,6 +1,6 @@
 import { getAddress } from '@ethersproject/address'
+import { getContractName, getGovernorBravoSlots } from '../utils/clients/tenderly'
 import { ProposalCheck, StateDiff } from '../types'
-import { getGovernorBravoSlots } from '../utils/clients/tenderly'
 
 /**
  * Reports all state changes from the proposal
@@ -45,14 +45,7 @@ export const checkStateChanges: ProposalCheck = {
     for (const [address, diffs] of Object.entries(stateDiffs)) {
       // Use contracts array to get contract name of address
       const contract = sim.contracts.find((c) => c.address === address)
-      let contractName = contract?.contract_name
-
-      // If the contract is a token, include the full token name. This is useful in cases where the
-      // token is a proxy, so the contract name doesn't give much useful information
-      if (contract?.token_data?.name) contractName += ` (${contract?.token_data?.name})`
-
-      // Lastly, append the contract address and save it off
-      info += `\n    - ${contractName} at \`${address}\``
+      info += `\n    - ${getContractName(contract)}`
 
       // Parse each diff. A single diff may involve multiple storage changes, e.g. a proposal that
       // executes three transactions will show three state changes to the `queuedTransactions`

--- a/checks/index.ts
+++ b/checks/index.ts
@@ -4,10 +4,17 @@ import {
 } from './check-targets-verified-etherscan'
 import { checkStateChanges } from './check-state-changes'
 import { checkLogs } from './check-logs'
+import { checkSlither } from './check-slither'
 import { ProposalCheck } from '../types'
 
 const ALL_CHECKS: {
   [checkId: string]: ProposalCheck
-} = { checkStateChanges, checkLogs, checkTargetsVerifiedEtherscan, checkTouchedContractsVerifiedEtherscan }
+} = {
+  checkStateChanges,
+  checkLogs,
+  checkTargetsVerifiedEtherscan,
+  checkTouchedContractsVerifiedEtherscan,
+  checkSlither,
+}
 
 export default ALL_CHECKS

--- a/utils/clients/tenderly.ts
+++ b/utils/clients/tenderly.ts
@@ -18,6 +18,7 @@ import {
   SimulationConfigExecuted,
   SimulationConfigProposed,
   SimulationResult,
+  TenderlyContract,
   TenderlyPayload,
   TenderlySimulation,
 } from '../../types'
@@ -203,6 +204,22 @@ const sleep = (delay: number) => new Promise((resolve) => setTimeout(resolve, de
 
 // Get a random integer between two values
 const randomInt = (min: number, max: number) => Math.floor(Math.random() * (max - min) + min) // max is exclusive, min is inclusive
+
+/**
+ * @notice Given a Tenderly contract object, generates a descriptive human-friendly name for that contract
+ * @param contract Tenderly contract object to generate name from
+ */
+export function getContractName(contract: TenderlyContract | undefined) {
+  if (!contract) return 'unknown contract name'
+  let contractName = contract?.contract_name
+
+  // If the contract is a token, include the full token name. This is useful in cases where the
+  // token is a proxy, so the contract name doesn't give much useful information
+  if (contract?.token_data?.name) contractName += ` (${contract?.token_data?.name})`
+
+  // Lastly, append the contract address and save it off
+  return `${contractName} at \`${getAddress(contract.address)}\``
+}
 
 /**
  * @notice Sends a transaction simulation request to the Tenderly API

--- a/utils/clients/tenderly.ts
+++ b/utils/clients/tenderly.ts
@@ -9,7 +9,7 @@ import { provider } from './ethers'
 
 import fetchUrl, { FETCH_OPT } from 'micro-ftch'
 import { governorBravo } from '../contracts/governor-bravo'
-import { BLOCK_GAS_LIMIT, TENDERLY_ACCESS_TOKEN, TENDERLY_URL } from '../constants'
+import { BLOCK_GAS_LIMIT, TENDERLY_ACCESS_TOKEN, TENDERLY_BASE_URL, TENDERLY_SIM_URL } from '../constants'
 import {
   ProposalActions,
   ProposalEvent,
@@ -22,6 +22,8 @@ import {
   TenderlyPayload,
   TenderlySimulation,
 } from '../../types'
+
+const TENDERLY_FETCH_OPTIONS = { type: 'json', headers: { 'X-Access-Key': TENDERLY_ACCESS_TOKEN } }
 
 // --- Simulation methods ---
 
@@ -43,7 +45,8 @@ async function simulateProposed(config: SimulationConfigProposed): Promise<Simul
   const { governorAddress, proposalId } = config
 
   // --- Get details about the proposal we're simulating ---
-  const latestBlock = await provider.getBlock('latest')
+  const network = await provider.getNetwork()
+  const latestBlock = await provider.getBlock(getLatestBlock(network.chainId))
   const blockRange = [0, latestBlock.number]
   const governor = governorBravo(governorAddress)
 
@@ -116,7 +119,7 @@ async function simulateProposed(config: SimulationConfigProposed): Promise<Simul
   const simulationPayload: TenderlyPayload = {
     network_id: '1',
     // this field represents the block state to simulate against, so we use the latest block number
-    block_number: latestBlock.number - 1, // subtract 1 to ensure block is mined and "finalized"
+    block_number: latestBlock.number,
     from,
     to: governor.address,
     input: governor.interface.encodeFunctionData('execute', [proposal.id]),
@@ -222,6 +225,19 @@ export function getContractName(contract: TenderlyContract | undefined) {
 }
 
 /**
+ * Gets the latest block number known to Tenderly
+ * @param chainId Chain ID to get block number for
+ */
+async function getLatestBlock(chainId: BigNumberish): Promise<number> {
+  // Send simulation request
+  const fetchOptions = <Partial<FETCH_OPT>>{ method: 'GET', ...TENDERLY_FETCH_OPTIONS }
+  const res = <{ block_number: number }>(
+    await fetchUrl(`${TENDERLY_BASE_URL}/network/${BigNumber.from(chainId).toString()}/block-number`, fetchOptions)
+  )
+  return res.block_number
+}
+
+/**
  * @notice Sends a transaction simulation request to the Tenderly API
  * @dev Uses a simple exponential backoff when requests fail, with the following parameters:
  *   - Initial delay is 1 second
@@ -233,13 +249,8 @@ export function getContractName(contract: TenderlyContract | undefined) {
 async function sendSimulation(payload: TenderlyPayload, delay = 1000): Promise<TenderlySimulation> {
   try {
     // Send simulation request
-    const fetchOptions = <Partial<FETCH_OPT>>{
-      method: 'POST',
-      type: 'json',
-      headers: { 'X-Access-Key': TENDERLY_ACCESS_TOKEN },
-      data: payload,
-    }
-    const sim = <TenderlySimulation>await fetchUrl(TENDERLY_URL, fetchOptions)
+    const fetchOptions = <Partial<FETCH_OPT>>{ method: 'POST', data: payload, ...TENDERLY_FETCH_OPTIONS }
+    const sim = <TenderlySimulation>await fetchUrl(TENDERLY_SIM_URL, fetchOptions)
 
     // Post-processing to ensure addresses we use are checksummed (since ethers returns checksummed addresses)
     sim.transaction.addresses = sim.transaction.addresses.map(getAddress)

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -3,7 +3,8 @@ export const BLOCK_GAS_LIMIT = 30_000_000
 export const RPC_URL: string = process.env.RPC_URL!
 export const RUNNING_LOCALLY = [0, '0', false, 'false'].includes(process.env.RUNNING_LOCALLY!) ? false : true
 export const TENDERLY_ACCESS_TOKEN: string = process.env.TENDERLY_ACCESS_TOKEN!
-export const TENDERLY_URL = `https://api.tenderly.co/api/v1/account/me/project/${process.env.TENDERLY_PROJECT_SLUG}/simulate`
+export const TENDERLY_BASE_URL = `https://api.tenderly.co/api/v1`
+export const TENDERLY_SIM_URL = `${TENDERLY_BASE_URL}/account/me/project/${process.env.TENDERLY_PROJECT_SLUG}/simulate`
 
 // Only required when running a specific sim from a config file
 // Note that if SIM_NAME is defined, that simulation takes precedence over scanning mode with GitHub Actions


### PR DESCRIPTION
- Adds a proposal check that runs [slither](https://github.com/crytic/slither) against all touched, verified contracts
- Also runs the slither `human-summary` printer
- Assumes the user has [solc-select](https://github.com/crytic/solc-select) and slither installed with python
- Note for nix/dapptools users: Make sure that in your `$PATH` variable, the path to python executables (which can be found with `which solc-select`) comes before the path to your nix executables. This may require editing your `$PATH` variable prior to running this check. If you don't do this, the nix version of `solc` will take precedence over the `solc-select` version, and slither will fail if `solc` points to the wrong version
- Skips running slither on the existing timelock, governor proxy, or governor implementation. Note that an archive node is needed to know the governor implementation address on past proposals, and if not found a warning will be printer