### PR TITLE
Solc check

### DIFF
--- a/checks/check-slither.ts
+++ b/checks/check-slither.ts
@@ -72,21 +72,18 @@ export const checkSlither: ProposalCheck = {
 }
 
 /**
- * Tries to run slither via python installation in the specified directory. If a printer name is
- * passed, the printer will be run.
+ * Tries to run slither via python installation in the specified directory.
  * @dev If you have nix/dapptools installed, you'll need to make sure the path to your python
  * executables (find this with `which solc-select`) comes before the path to your nix executables.
  * This may require editing your $PATH variable prior to running this check. If you don't do this,
- * the nix version of solc will take precedence over the solc-select version, and slither will fail
- * @dev The list of available printers can be found here: https://github.com/crytic/slither/wiki/Printer-documentation
+ * the nix version of solc will take precedence over the solc-select version, and slither will fail.
  */
-async function runSlither(address: string, printer: string | undefined = undefined): Promise<ExecOutput | null> {
+async function runSlither(address: string): Promise<ExecOutput | null> {
   try {
-    const printerCmd = printer ? ` --print ${printer}` : ''
-    return await exec(`slither ${address}${printerCmd} --etherscan-apikey ${ETHERSCAN_API_KEY}`)
+    return await exec(`slither ${address} --etherscan-apikey ${ETHERSCAN_API_KEY}`)
   } catch (e: any) {
-    if ('stderr' in e) return e // output is in stderr, but slither reports results as an exception
-    console.warn(`Error: Could not run slither${printer ? ` printer ${printer}` : ''} via Python: ${JSON.stringify(e)}`)
+    if ('stderr' in e) return e // Output is in stderr, but slither reports results as an exception.
+    console.warn(`Error: Could not run slither via Python: ${JSON.stringify(e)}`)
     return null
   }
 }

--- a/checks/index.ts
+++ b/checks/index.ts
@@ -5,6 +5,7 @@ import {
 import { checkDecodeCalldata } from './check-decode-calldata'
 import { checkLogs } from './check-logs'
 import { checkSlither } from './check-slither'
+import { checkSolc } from './check-solc'
 import { checkStateChanges } from './check-state-changes'
 import { ProposalCheck } from '../types'
 
@@ -16,6 +17,9 @@ const ALL_CHECKS: {
   checkLogs,
   checkTargetsVerifiedEtherscan,
   checkTouchedContractsVerifiedEtherscan,
+  // The solc check must be run before the slither check, because the compilation exports a zip file
+  // which is consumed by slither. This prevents us from having to compile the contracts twice.
+  checkSolc,
   checkSlither,
 }
 


### PR DESCRIPTION
Closes https://github.com/Uniswap/governance-seatbelt/issues/49

The solc and slither checks are pretty similar:
- Both compile contracts from Etherscan
- They share a lot of the same logic

Right now, this means we compile contracts twice and have some code duplicated. I'd like to cut down on this, but want to think about the best way to do it. One approach is to have the solc check export a zip file, and have slither consume that zip file instead of re-compiling contracts.

However, I didn't do that right now are because it couples the two checks, and makes the ordering matter. Additionally we currently use a `Promise.all` to execute proposal checks, which wouldn't work if the ordering of those two checks matters. Tracking this improvement in https://github.com/Uniswap/governance-seatbelt/issues/63