### PR TITLE
fix: properly handle SAI and REP tokens

### DIFF
--- a/checks/check-decode-calldata.ts
+++ b/checks/check-decode-calldata.ts
@@ -144,7 +144,7 @@ async function prettifyCalldata(call: FluffyCall, target: string) {
     // --- Custom descriptions for common methods ---
     // Custom descriptions add the word "formatted" to the end so it's clear that this is a custom error
     // message and all numbers with decimals have already been parsed to a human readable format.
-    // We decoded the calldata manually instead of relying on `call.decoded_input` because it's more
+    // We decode the calldata manually instead of relying on `call.decoded_input` because it's more
     // robust. Sometimes `call.decoded_input` may be undefined when Tenderly is not familiar with a
     // given proxy pattern, but since this is known calldata we know how it should be decoded regardless.
     case '0x095ea7b3': {

--- a/checks/check-decode-calldata.ts
+++ b/checks/check-decode-calldata.ts
@@ -2,8 +2,10 @@ import { FunctionFragment, Interface } from '@ethersproject/abi'
 import { getAddress } from '@ethersproject/address'
 import { formatUnits } from '@ethersproject/units'
 import { ProposalCheck, FluffyCall } from '../types'
-import { fetchTokenMetadata } from '../utils/contracts/erc20'
+import { ERC20_ABI, fetchTokenMetadata } from '../utils/contracts/erc20'
 import { bullet } from '../presentation/report'
+
+const ierc20 = new Interface(ERC20_ABI)
 
 /**
  * Decodes proposal target calldata into a human-readable format
@@ -141,21 +143,27 @@ async function prettifyCalldata(call: FluffyCall, target: string) {
   switch (selector) {
     // --- Custom descriptions for common methods ---
     // Custom descriptions add the word "formatted" to the end so it's clear that this is a custom error
-    // message and all numbers with decimals have already been parsed to a human readable format
+    // message and all numbers with decimals have already been parsed to a human readable format.
+    // We decoded the calldata manually instead of relying on `call.decoded_input` because it's more
+    // robust. Sometimes `call.decoded_input` may be undefined when Tenderly is not familiar with a
+    // given proxy pattern, but since this is known calldata we know how it should be decoded regardless.
     case '0x095ea7b3': {
-      const spender = getAddress(call.decoded_input?.[0].value as string)
-      const amount = formatUnits(call.decoded_input?.[1].value as string, decimals)
+      const decodedCalldata = ierc20.decodeFunctionData('approve', call.input)
+      const spender = getAddress(decodedCalldata.spender)
+      const amount = formatUnits(decodedCalldata.value, decimals)
       return `\`${call.from}\` approves \`${spender}\` to spend ${amount} ${symbol} (formatted)`
     }
     case '0xba45b0b8': {
-      const receiver = getAddress(call.decoded_input?.[0].value as string)
-      const amount = formatUnits(call.decoded_input?.[1].value as string, decimals)
+      const decodedCalldata = ierc20.decodeFunctionData('transfer', call.input)
+      const receiver = getAddress(decodedCalldata.to)
+      const amount = formatUnits(decodedCalldata.value, decimals)
       return `\`${call.from}\` transfers \`${amount}\` ${symbol} to ${receiver} (formatted)`
     }
     case '0x23b872dd': {
-      const from = getAddress(call.decoded_input?.[0].value as string)
-      const to = getAddress(call.decoded_input?.[1].value as string)
-      const amount = formatUnits(call.decoded_input?.[2].value as string, decimals)
+      const decodedCalldata = ierc20.decodeFunctionData('transferFrom', call.input)
+      const from = getAddress(decodedCalldata.from)
+      const to = getAddress(decodedCalldata.to)
+      const amount = formatUnits(decodedCalldata.value, decimals)
       return `\`${call.from}\` transfers \`${amount}\` ${symbol} from ${from} to ${to} (formatted)`
     }
   }

--- a/utils/contracts/erc20.ts
+++ b/utils/contracts/erc20.ts
@@ -1,10 +1,10 @@
 import { Contract } from 'ethers'
 import { provider } from '../clients/ethers'
+import { getAddress } from '@ethersproject/address'
 
-export const ERC20_ABI = [
-  'function name() public view returns (string)',
-  'function symbol() public view returns (string)',
-  'function decimals() public view returns (uint8)',
+const SAI = '0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359'
+
+const ERC20_BASE_ABI = [
   'function balanceOf(address owner) public view returns (uint256 balance)',
   'function transfer(address to, uint256 value) public returns (bool success)',
   'function transferFrom(address from, address to, uint256 value) public returns (bool success)',
@@ -14,8 +14,23 @@ export const ERC20_ABI = [
   'event Approval(address indexed owner, address indexed spender, uint256 value)',
 ]
 
+export const ERC20_ABI = [
+  'function name() public view returns (string)',
+  'function symbol() public view returns (string)',
+  'function decimals() public view returns (uint8)',
+  ...ERC20_BASE_ABI,
+]
+
+export const SAI_ABI = [
+  'function name() public view returns (bytes32)',
+  'function symbol() public view returns (bytes32)',
+  'function decimals() public view returns (uint256)',
+  ...ERC20_BASE_ABI,
+]
+
 export async function fetchTokenMetadata(address: string) {
-  const token = new Contract(address, ERC20_ABI, provider)
+  const abi = getAddress(address) === SAI ? SAI_ABI : ERC20_ABI
+  const token = new Contract(address, abi, provider)
   const response = await Promise.all([token.name(), token.symbol(), token.decimals()])
   return {
     name: response[0] as string,


### PR DESCRIPTION
- SAI returns bytes32 for name/symbol, instead of string
- REP is a non-standard proxy pattern that tenderly does not recognize

This resolves the failures when running proposal checks against Compound's [proposal 138](https://compound.finance/governance/proposals/138). Sample CI failure [here](https://github.com/Uniswap/governance-seatbelt/actions/runs/3664096895/jobs/6194293907).

Kicked off https://github.com/Uniswap/governance-seatbelt/actions/runs/3664956794 to test this fix