### PR TITLE
fix: proposal with callvalue

### DIFF
--- a/utils/clients/tenderly.ts
+++ b/utils/clients/tenderly.ts
@@ -269,11 +269,14 @@ async function simulateProposed(config: SimulationConfigProposed): Promise<Simul
   if (!proposalCreatedEvent) throw new Error(`Proposal creation log for #${proposalId} not found in governor logs`)
   const {
     targets,
-    values,
     signatures: sigs,
     calldatas,
     description,
   } = proposalCreatedEvent.args as unknown as ProposalEvent
+  // workaround an issue that ethers cannot decode the values properly
+  // we know that the values are the 3rd parameter in
+  // ProposalCreated(proposalId, proposer, targets, values, signatures, calldatas, startBlock, endBlock, description)
+  const values: BigNumber[] = proposalCreatedEvent.args![3]
 
   // --- Prepare simulation configuration ---
   // We need the following state conditions to be true to successfully simulate a proposal:


### PR DESCRIPTION
This PR workaround [an issue](https://github.com/gzeoneth/governance-seatbelt/blob/c340d400291f701e7bb9c71fb13d68a5fd25fe22/utils/clients/tenderly.ts#L331) that ethers cannot decode the values in ProposalCreated event properly

Also here is the Uniswap proposal 29 report generated with this branch [29.pdf](https://github.com/Uniswap/governance-seatbelt/files/10272078/29.pdf) / [29.md](https://github.com/Uniswap/governance-seatbelt/files/10272087/29.md)