### PR TITLE
ci: always generate reports

### DIFF
--- a/.github/workflows/governance-checks.yaml
+++ b/.github/workflows/governance-checks.yaml
@@ -75,6 +75,9 @@ jobs:
           GOVERNOR_ADDRESS: ${{ matrix.GOVERNOR_ADDRESS }}
 
       - name: Upload artifacts
+        # We always upload artifacts, even if certain proposal sims/checks failed. This is because
+        # we don't want to block generating all reports for all DAOs when a single one fails.
+        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.DAO_NAME }}

--- a/.github/workflows/governance-checks.yaml
+++ b/.github/workflows/governance-checks.yaml
@@ -11,6 +11,8 @@ on:
 jobs:
   check-proposals:
     strategy:
+      # Set fail-fast to false to ensure all Matrix runs complete even if one fails.
+      fail-fast: false
       matrix:
         include:
           - DAO_NAME: 'Uniswap'

--- a/checks/check-state-changes.ts
+++ b/checks/check-state-changes.ts
@@ -23,10 +23,6 @@ export const checkStateChanges: ProposalCheck = {
     // recording state changes for (1) the the `queuedTransactions` mapping of the timelock, and
     // (2) the `proposal.executed` change of the governor, because this will be consistent across
     // all proposals and mainly add noise to the output
-    console.log(
-      'sim.transaction.transaction_info.state_diff: ',
-      JSON.stringify(sim.transaction.transaction_info.state_diff, null, 2)
-    )
     const stateDiffs = sim.transaction.transaction_info.state_diff.reduce((diffs, diff) => {
       const addr = getAddress(diff.raw[0].address)
       // Check if this is a diff that should be filtered out

--- a/checks/check-state-changes.ts
+++ b/checks/check-state-changes.ts
@@ -23,6 +23,10 @@ export const checkStateChanges: ProposalCheck = {
     // recording state changes for (1) the the `queuedTransactions` mapping of the timelock, and
     // (2) the `proposal.executed` change of the governor, because this will be consistent across
     // all proposals and mainly add noise to the output
+    console.log(
+      'sim.transaction.transaction_info.state_diff: ',
+      JSON.stringify(sim.transaction.transaction_info.state_diff, null, 2)
+    )
     const stateDiffs = sim.transaction.transaction_info.state_diff.reduce((diffs, diff) => {
       const addr = getAddress(diff.raw[0].address)
       // Check if this is a diff that should be filtered out

--- a/utils/clients/tenderly.ts
+++ b/utils/clients/tenderly.ts
@@ -525,6 +525,7 @@ async function sendEncodeRequest(payload: any): Promise<StorageEncodingResponse>
   } catch (err) {
     console.log('logging sendEncodeRequest error')
     console.log(JSON.stringify(err, null, 2))
+    console.log(JSON.stringify(payload))
     throw err
   }
 }


### PR DESCRIPTION
Changes CI to always upload artifacts, even if certain proposal sims/checks failed. This is so we don't block generating all reports for all DAOs when a single sim for a single DAO fails.

Test CI run here: https://github.com/Uniswap/governance-seatbelt/actions/runs/3759350814