### PR TITLE
fix: include callvalue in execution simulation

### DIFF
--- a/utils/clients/tenderly.ts
+++ b/utils/clients/tenderly.ts
@@ -387,7 +387,7 @@ async function simulateProposed(config: SimulationConfigProposed): Promise<Simul
     input: governor.interface.encodeFunctionData('execute', executeInputs),
     gas: BLOCK_GAS_LIMIT,
     gas_price: '0',
-    value: '0', // The proposal executor should not need to send value to execute the proposal.
+    value: values.reduce((a, b) => a.add(b), BigNumber.from(0)).toString(), // The proposal executor may need to send value to execute the proposal.
     save_if_fails: false, // Set to true to save the simulation to your Tenderly dashboard if it fails.
     save: false, // Set to true to save the simulation to your Tenderly dashboard if it succeeds.
     generate_access_list: true, // not required, but useful as a sanity check to ensure consistency in the simulation response


### PR DESCRIPTION
Proposal (e.g. [32](https://www.tally.xyz/gov/uniswap/proposal/32)) may require call value, which can come from the timelock or the executor. Either the proposer can send the eth to the timelock ahead of time, or the seatbelt can include the callvalue for simulation. This PR add the sum of call values to the execution simulation.