### PR TITLE
feat/sim with value

### DIFF
--- a/checks/check-value-required.ts
+++ b/checks/check-value-required.ts
@@ -9,10 +9,7 @@ import { ProposalCheck } from '../types'
 export const checkValueRequired: ProposalCheck = {
   name: 'Reports on whether the caller needs to send ETH with the call',
   async checkProposal(proposal, sim, deps) {
-    // TODO Fix typings for values. The `values` field is not present in the proposal object, but
-    // key `3` contains them. (Similarly key 0 is proposal ID, 1 is proposer, etc.)
-    type ProposalValues = { '3': BigNumber[] }
-    const totalValue = (proposal as unknown as ProposalValues)['3'].reduce((sum, cur) => sum.add(cur), Zero)
+    const totalValue = proposal.values.reduce((sum, cur) => sum.add(cur), Zero)
 
     const txValue = BigNumber.from(sim.simulation.value)
     if (txValue.eq(Zero)) {

--- a/checks/check-value-required.ts
+++ b/checks/check-value-required.ts
@@ -1,0 +1,34 @@
+import { Zero } from '@ethersproject/constants'
+import { BigNumber } from '@ethersproject/bignumber'
+import { formatEther } from '@ethersproject/units'
+import { ProposalCheck } from '../types'
+
+/**
+ * Reports on whether the caller initiating the `execute` call needs to send ETH with the call.
+ */
+export const checkValueRequired: ProposalCheck = {
+  name: 'Reports on whether the caller needs to send ETH with the call',
+  async checkProposal(proposal, sim, deps) {
+    // TODO Fix typings for values. The `values` field is not present in the proposal object, but
+    // key `3` contains them. (Similarly key 0 is proposal ID, 1 is proposer, etc.)
+    type ProposalValues = { '3': BigNumber[] }
+    const totalValue = (proposal as unknown as ProposalValues)['3'].reduce((sum, cur) => sum.add(cur), Zero)
+
+    const txValue = BigNumber.from(sim.simulation.value)
+    if (txValue.eq(Zero)) {
+      const msg = 'No ETH is required to be sent by the account that executes this proposal.'
+      return { info: [msg], warnings: [], errors: [] }
+    }
+
+    const valueRequired = formatEther(totalValue)
+    const govBalance = formatEther(await deps.provider.getBalance(deps.governor.address))
+    const valueSent = formatEther(txValue)
+
+    const msg1 = 'The account that executes this proposal will need to send ETH along with the transaction.'
+    const msg2 = `The calls made by this proposal require a total of ${valueRequired} ETH, and the Governor contract has ${govBalance} ETH.`
+    const msg3 = `As a result, the account that executes this proposal will need to send ${valueSent} ETH along with the transaction.`
+    const msg = `${msg1}\n\n${msg2} ${msg3}`
+
+    return { info: [], warnings: [msg], errors: [] }
+  },
+}

--- a/checks/check-value-required.ts
+++ b/checks/check-value-required.ts
@@ -9,7 +9,11 @@ import { ProposalCheck } from '../types'
 export const checkValueRequired: ProposalCheck = {
   name: 'Reports on whether the caller needs to send ETH with the call',
   async checkProposal(proposal, sim, deps) {
-    const totalValue = proposal.values.reduce((sum, cur) => sum.add(cur), Zero)
+    // TODO Fix typings for values. The `values` field is not present in the proposal object, but
+    // key `3` contains them. (Similarly key 0 is proposal ID, 1 is proposer, etc.). This is related
+    // to why we use `proposalCreatedEvent.args![3]` in `tenderly.ts`.
+    type ProposalValues = { '3': BigNumber[] }
+    const totalValue = (proposal as unknown as ProposalValues)['3'].reduce((sum, cur) => sum.add(cur), Zero)
 
     const txValue = BigNumber.from(sim.simulation.value)
     if (txValue.eq(Zero)) {

--- a/checks/check-value-required.ts
+++ b/checks/check-value-required.ts
@@ -9,11 +9,15 @@ import { ProposalCheck } from '../types'
 export const checkValueRequired: ProposalCheck = {
   name: 'Reports on whether the caller needs to send ETH with the call',
   async checkProposal(proposal, sim, deps) {
-    // TODO Fix typings for values. The `values` field is not present in the proposal object, but
-    // key `3` contains them. (Similarly key 0 is proposal ID, 1 is proposer, etc.). This is related
-    // to why we use `proposalCreatedEvent.args![3]` in `tenderly.ts`.
+    // TODO Fix typings for values. The `values` field is not always present in the proposal object,
+    // but key `3` contains them. (Similarly key 0 is proposal ID, 1 is proposer, etc.). This is
+    // related to why we use `proposalCreatedEvent.args![3]` in `tenderly.ts`.
     type ProposalValues = { '3': BigNumber[] }
-    const totalValue = (proposal as unknown as ProposalValues)['3'].reduce((sum, cur) => sum.add(cur), Zero)
+    const totalValue = proposal.values
+      ? // For local simulations, `values` exists and `3` does not.
+        proposal.values.reduce((sum, cur) => sum.add(cur), Zero)
+      : // For simulations read from the chain, `3` exists and `values` does not.
+        (proposal as unknown as ProposalValues)['3'].reduce((sum, cur) => sum.add(cur), Zero)
 
     const txValue = BigNumber.from(sim.simulation.value)
     if (txValue.eq(Zero)) {

--- a/checks/index.ts
+++ b/checks/index.ts
@@ -7,6 +7,7 @@ import { checkLogs } from './check-logs'
 import { checkSlither } from './check-slither'
 import { checkSolc } from './check-solc'
 import { checkStateChanges } from './check-state-changes'
+import { checkValueRequired } from './check-value-required'
 import { ProposalCheck } from '../types'
 
 const ALL_CHECKS: {
@@ -17,6 +18,7 @@ const ALL_CHECKS: {
   checkLogs,
   checkTargetsVerifiedEtherscan,
   checkTouchedContractsVerifiedEtherscan,
+  checkValueRequired,
   // The solc check must be run before the slither check, because the compilation exports a zip file
   // which is consumed by slither. This prevents us from having to compile the contracts twice.
   checkSolc,

--- a/presentation/report.ts
+++ b/presentation/report.ts
@@ -62,7 +62,8 @@ function toMessageList(header: string, text: string[]): string {
  * @param name the descriptive name of the check
  */
 function toCheckSummary({ result: { errors, warnings, info }, name }: AllCheckResults[string]): string {
-  const status = errors.length === 0 ? (warnings.length === 0 ? '✅ Passed' : '⚠️ Passed with warnings') : '❌ Failed'
+  const status =
+    errors.length === 0 ? (warnings.length === 0 ? '✅ Passed' : '❗❗ **Passed with warnings**') : '❌ **Failed**'
 
   return `### ${name} ${status}
 
@@ -214,7 +215,7 @@ function remarkFixEmojiLinks() {
         const isInternalLink = url.startsWith('#')
         if (isInternalLink && url.endsWith('--passed-with-warnings')) {
           // @ts-ignore node.url does exist, the typings just aren't correct
-          node.url = node.url.replace('--passed-with-warnings', '-⚠️-passed-with-warnings')
+          node.url = node.url.replace('--passed-with-warnings', '-❗❗-passed-with-warnings')
         } else if (isInternalLink && url.endsWith('--passed')) {
           // @ts-ignore node.url does exist, the typings just aren't correct
           node.url = node.url.replace('--passed', '-✅-passed')


### PR DESCRIPTION
Replaces #101, see conversation in that PR for context.

New logic for whether or not the `from` account should send value with the transaction is as follows. We stop simulating when any of the simulations below are successful:
1. Try simulating zero value.
2. If that failed, sum up the value of of all calls in the proposal, subtract the governor's balance, and re-sim by sending that difference.
3. If that failed, repeat previous step but without subtracting governor balance.

CI run to test: https://github.com/Uniswap/governance-seatbelt/actions/runs/4130176804

cc @gzeoneth, let me know what you think of this solution