### PR TITLE
fix: ignored state change

### DIFF
--- a/checks/check-state-changes.ts
+++ b/checks/check-state-changes.ts
@@ -67,13 +67,6 @@ export const checkStateChanges: ProposalCheck = {
       // mapping within a single `diff` element. We always JSON.stringify the values so structs
       // (i.e. tuples) don't print as [object Object]
       diffs.forEach((diff) => {
-        // Sometimes Tenderly will return state changes where the original value is null, which
-        // means the original and dirty (new) values are the same. This is currently a bug, but it
-        // only happens when the original and dirty values match (i.e. no storage was changed,
-        // because the slot went from original -> other value -> original). As a result we can
-        // safely skip these diffs.
-        if (diff.original === null) return
-
         if (!diff.soltype) {
           // In this branch, state change is not decoded, so return raw data of each storage write
           // (all other branches have decoded state changes)


### PR DESCRIPTION
Tenderly no longer return diff.original === null for storage slot that went from original -> other value -> original, but instead will have diff.original === null for un-decoded slot. Removing the ignore to make sure seatbelt surface those storage changes.

* https://github.com/ArbitrumFoundation/governance-seatbelt/pull/27